### PR TITLE
Add "Skip to main content" link to default layout

### DIFF
--- a/template/nuxt-app/layouts/default.vue
+++ b/template/nuxt-app/layouts/default.vue
@@ -3,13 +3,14 @@
 <template lang='pug'>
 
 .default-layout
+	a.skip-content(href='#main') Skip to main content
 
 	//- Header stuff
 	layout-header-desktop
 	layout-header-mobile
 
 	//- Page content
-	main
+	main#main
 		nuxt.page
 		layout-footer
 
@@ -41,5 +42,15 @@ main
 	margin-h auto
 	width 100%
 	overflow hidden
+
+.skip-content
+	position absolute
+	left -1000px
+	top (header-h + 10px)
+	z-index header-z // stacked below nav but above page content
+
+	&:focus
+		left 10px
+		outline none
 
 </style>

--- a/template/nuxt-app/layouts/default.vue
+++ b/template/nuxt-app/layouts/default.vue
@@ -46,11 +46,14 @@ main
 .skip-content
 	position absolute
 	left -1000px
-	top (header-h + 10px)
+	+tablet-up()
+		top (header-h + spacing-s)
+	+tablet-down()
+		top (header-h-mobile + spacing-s-min)
 	z-index header-z // stacked below nav but above page content
 
 	&:focus
-		left 10px
+		fluid left, gutter, gutter-mobile
 		outline none
 
 </style>


### PR DESCRIPTION
I tried to keep it simple.  It's a mostly unstyled link, positioned offscreen.  When focused, it appears in the top left immediately below the top nav.  I opted to put it below the nav and not inside the nav, because below tablet the logo usually occupies the top left and I don't want them to collide.

![Kapture 2021-09-03 at 13 38 43](https://user-images.githubusercontent.com/6802815/132063092-7441ef5b-f7e3-48b2-b2b7-e5bfa2cbe025.gif)
