### PR TITLE
Use `hover` stylus mixin instead of unknown `hover-focus` mixin

### DIFF
--- a/template/nuxt-app/components/globals/btn/btn.vue
+++ b/template/nuxt-app/components/globals/btn/btn.vue
@@ -112,7 +112,7 @@ export default
 
 	// Add hover/active effects
 	&:not([disabled])
-		+hover-focus(true)
+		+hover(true)
 			.shape
 				background primary-color-dark
 				transition-duration .2s


### PR DESCRIPTION
`btn.vue` uses this `hover-focus` stylus mixin.  I don't have this mixin, and I don't know where to find it.  

We should either:
- Add `hover-focus` to bukwild-stylus-library, or 
- Use bukwild-stylus-library's existing `hover` mixin instead.

In this PR I'm switching to use the `hover` mixin.