### PR TITLE
Adding vue-modal, vue-forms, vue-hamburger, and vue-embed

### DIFF
--- a/template/nuxt-app/package.json
+++ b/template/nuxt-app/package.json
@@ -25,6 +25,9 @@
 	"dependencies": {
 		"@bkwld/cloak": "^1.13.0",
 		"@bkwld/light-or-dark": "^1.0.1",
+		"@bkwld/vue-embed": "BKWLD/vue-embed#ab9fc58",
+		"@bkwld/vue-modal": "BKWLD/vue-modal#7313bd5",
+		"@bkwld/vue-form": "BKWLD/vue-form#ee83e3e",
 		<%_ if (cms == '@nuxt/content') { _%>
 		"@nuxt/content": "1.14.0",
 		<%_ } _%>
@@ -34,6 +37,7 @@
 		<%_ } _%>
 		"vue-balance-text": "^1.2.3",
 		"vue-detachable-header": "^0.2.0",
+		"vue-hamburger": "^1.0.0",
 		"vue-unorphan": "^1.2.3"
 	}
 }

--- a/template/nuxt-app/plugins/components.coffee
+++ b/template/nuxt-app/plugins/components.coffee
@@ -10,3 +10,18 @@ Vue.component 'smart-link', SmartLink
 import ShopifyVisual from 'library/components/globals/shopify-visual'
 Vue.component 'shopify-visual', ShopifyVisual
 <%_ } _%>
+
+
+# Modal
+import Modal from '@bkwld/vue-modal'
+Vue.component 'modal', Modal
+import '@bkwld/vue-modal/index.css'
+
+# Embed wysiwyg
+import Embed from '@bkwld/vue-embed'
+Vue.component 'vue-embed', Embed
+
+# Hamburger
+import Hamburger from 'vue-hamburger'
+Vue.component 'hamburger', Hamburger
+import 'vue-hamburger/index.css'


### PR DESCRIPTION
@weotch not sure what you think about this, but I couldn't think of a good reason _not to add_ these, since these seem pretty universal, and something we'd want to support on every proj. 

One thought about `vue-embed` though, is that it's more tied to Craft, but really it just accepts some HTML, which could come from contentful or whatever also. 

Anyways, let me know if you have contrary thoughts to adding these out of the box