### PR TITLE
Adding body-scroll-lock dependancy

### DIFF
--- a/template/nuxt-app/package.json
+++ b/template/nuxt-app/package.json
@@ -28,6 +28,7 @@
 		<%_ if (cms == '@nuxt/content') { _%>
 		"@nuxt/content": "1.14.0",
 		<%_ } _%>
+		"body-scroll-lock": "^3.0.2",
 		"nuxt": "^2.15.7",
 		<%_ if (shopify) { _%>
 		"shopify-gtm-instrumentor": "^1.3.0",


### PR DESCRIPTION
@weotch another consideration for you. I can't think of a site we would build that _wouldn't need some sort of scroll locking_, like modals, mobile menu, cart flyout, etc. 

Up to you though, just thought I would propose it here.