### PR TITLE
fixed color for disabled button, added btn to style-guide, updated co…

### DIFF
--- a/template/nuxt-app/assets/vars/colors.json
+++ b/template/nuxt-app/assets/vars/colors.json
@@ -3,6 +3,7 @@
 	"primary-color-dark": "#008c44",
 	"secondary-color": "#e8179e",
 	"offwhite": "#edf0f5",
+	"grey": "#cccccc",
 	"ui-border-color": "#e0e0e0",
 	"warning-color": "#AF4242"
 }

--- a/template/nuxt-app/assets/vars/colors.json
+++ b/template/nuxt-app/assets/vars/colors.json
@@ -3,7 +3,7 @@
 	"primary-color-dark": "#008c44",
 	"secondary-color": "#e8179e",
 	"offwhite": "#edf0f5",
-	"grey": "#cccccc",
+	"disabled-fill": "#cccccc",
 	"ui-border-color": "#e0e0e0",
 	"warning-color": "#AF4242"
 }

--- a/template/nuxt-app/components/globals/btn/btn.vue
+++ b/template/nuxt-app/components/globals/btn/btn.vue
@@ -134,6 +134,12 @@ export default
 	color white
 	fluid font-size, body-font-size, body-font-size-min
 
+	// Disabled state
+	&[disabled]
+		color darken(grey, 20%)
+		.shape
+			background-color grey
+
 // Make backgound state
 .shape
 	expand()
@@ -145,10 +151,6 @@ export default
 		border-radius btn-mobile-h * 0.5
 		&.size-small
 			height btn-small-h * 0.5
-
-	// Disabled state
-	[disabled] &
-		background-color grey-bkgd
 
 .slot
 

--- a/template/nuxt-app/components/globals/btn/btn.vue
+++ b/template/nuxt-app/components/globals/btn/btn.vue
@@ -136,9 +136,9 @@ export default
 
 	// Disabled state
 	&[disabled]
-		color darken(grey, 20%)
+		color darken(disabled-fill, 20%)
 		.shape
-			background-color grey
+			background-color disabled-fill
 
 // Make backgound state
 .shape

--- a/template/nuxt-app/pages/style-guide.vue
+++ b/template/nuxt-app/pages/style-guide.vue
@@ -34,6 +34,21 @@
 		.swatch
 			.box.offwhite
 			label offwhite
+		.swatch
+			.box.grey
+			label grey
+		.swatch
+			.box.ui-border-color
+			label ui-border-color
+		.swatch
+			.box.warning-color
+			label warning-color
+
+	h1.header Buttons
+		.btn-wrap
+			btn Primary Button
+		.btn-wrap
+			btn(disabled) Disabled Button
 
 </template>
 
@@ -104,5 +119,18 @@ export default
 
 		&.offwhite
 			background offwhite
+
+		&.grey
+			background grey
+
+		&.ui-border-color
+			background white
+			border 1px solid ui-border-color
+
+		&.warning-color
+			background warning-color
+
+.btn-wrap
+	margin-bottom spacing-xs
 
 </style>

--- a/template/nuxt-app/pages/style-guide.vue
+++ b/template/nuxt-app/pages/style-guide.vue
@@ -35,8 +35,8 @@
 			.box.offwhite
 			label offwhite
 		.swatch
-			.box.grey
-			label grey
+			.box.disabled-fill
+			label disabled-fill
 		.swatch
 			.box.ui-border-color
 			label ui-border-color
@@ -120,8 +120,8 @@ export default
 		&.offwhite
 			background offwhite
 
-		&.grey
-			background grey
+		&.disabled-fill
+			background disabled-fill
 
 		&.ui-border-color
 			background white


### PR DESCRIPTION
@weotch I know i have been nickel-and-diming here, but I really like the style guide, and I want to make it more useful. 

- added a couple buttons
- added new swatches
- I noticed that the `grey-bkgd` style for disabled buttons wasn't defined anywhere. I'm using 'grey' now