### PR TITLE
max-w-wide wasn't set up in whitespace, but defined in definitions

### DIFF
--- a/template/nuxt-app/assets/whitespace.styl
+++ b/template/nuxt-app/assets/whitespace.styl
@@ -1,11 +1,11 @@
 // Common max-w* rules
-.max-w-small, .max-w-medium, .max-w
+.max-w-small, .max-w-medium, .max-w, .max-w-wide
 	margin-h auto
 	fluid(padding-h, gutter, gutter-mobile, max-break: desktop, min-break: mobile)
 	width 100%
 
 	// Clear padding on any nested classes, like if this was applied to a wrapper
-	.max-w-small, .max-w-medium, .max-w
+	.max-w-small, .max-w-medium, .max-w, .max-w-wide
 		padding-h 0
 
 // Apply varying max-widths
@@ -15,6 +15,8 @@
 	max-width max-w-medium
 .max-w
 	max-width max-w
+.max-w-wide
+	max-width max-w-wide
 
 // No gutters since there typically wraps other max-w-* instances that have
 // their own gutters


### PR DESCRIPTION
@weotch don't know if this was intentional, but I had to set this up in `whitespace.styl`, seems like it should be there. 
