### PR TITLE
consistent naming conventions for max-w

### DIFF
--- a/template/craft-cms/config/project/fields/maxWidth--2a3e1dff-e96a-4ac1-8a6e-7eed68dfaa4e.yaml
+++ b/template/craft-cms/config/project/fields/maxWidth--2a3e1dff-e96a-4ac1-8a6e-7eed68dfaa4e.yaml
@@ -11,10 +11,10 @@ settings:
       __assoc__:
         -
           - label
-          - 'Default - 1,280px wide'
+          - 'Large - 1,280px wide'
         -
           - value
-          - max-w
+          - max-w-l
         -
           - default
           - '1'
@@ -25,7 +25,7 @@ settings:
           - 'Medium - 1060px wide, for an indented effect '
         -
           - value
-          - max-w-medium
+          - max-w-m
         -
           - default
           - ''
@@ -36,7 +36,7 @@ settings:
           - 'Small - 750px wide, good for Copy blocks'
         -
           - value
-          - max-w-small
+          - max-w-s
         -
           - default
           - ''

--- a/template/nuxt-app/assets/definitions.styl
+++ b/template/nuxt-app/assets/definitions.styl
@@ -9,13 +9,13 @@ json('vars/colors.json')
 
 
 // Whitespace
+max-w-s = 750px + gutter * 2
+max-w-m = 1060px + gutter * 2
+max-w-l = 1280px + gutter * 2
+max-w-xl = 1440px
+max-w-full = 2560px
 gutter = 60px
 gutter-mobile = 20px
-max-w-small = 750px + gutter * 2
-max-w-medium = 1060px + gutter * 2
-max-w = 1280px + gutter * 2
-max-w-wide = 1440px
-max-w-full = 2560px
 
 // Header config
 header-z = 10

--- a/template/nuxt-app/assets/whitespace.styl
+++ b/template/nuxt-app/assets/whitespace.styl
@@ -1,22 +1,22 @@
 // Common max-w* rules
-.max-w-small, .max-w-medium, .max-w, .max-w-wide
+.max-w-s, .max-w-m, .max-l, .max-w-xl
 	margin-h auto
 	fluid(padding-h, gutter, gutter-mobile, max-break: desktop, min-break: mobile)
 	width 100%
 
 	// Clear padding on any nested classes, like if this was applied to a wrapper
-	.max-w-small, .max-w-medium, .max-w, .max-w-wide
+	.max-w-s, .max-w-m, .max-l, .max-w-xl
 		padding-h 0
 
 // Apply varying max-widths
-.max-w-small
-	max-width max-w-small
-.max-w-medium
-	max-width max-w-medium
-.max-w
-	max-width max-w
-.max-w-wide
-	max-width max-w-wide
+.max-w-s
+	max-width max-w-s
+.max-w-m
+	max-width max-w-m
+.max-w-l
+	max-width max-w-l
+.max-w-xl
+	max-width max-w-xl
 
 // No gutters since there typically wraps other max-w-* instances that have
 // their own gutters

--- a/template/nuxt-app/components/blocks/copy.vue
+++ b/template/nuxt-app/components/blocks/copy.vue
@@ -2,7 +2,7 @@
 
 <template lang='pug'>
 
-section.copy.max-w-small(:class='classes')
+section.copy.max-w-s(:class='classes')
 
 	<%_ if (cms == 'craft' || cms == '@nuxt/content') { _%>
 	wysiwyg(

--- a/template/nuxt-app/components/blocks/media-asset.vue
+++ b/template/nuxt-app/components/blocks/media-asset.vue
@@ -43,10 +43,10 @@ export default
 
 		# Map maxWidth options to classes
 		maxWidth: -> switch @block.maxWidth
-			when 'Medium' then 'max-w-medium'
-			when 'Small' then 'max-w-small'
+			when 'Medium' then 'max-w-m'
+			when 'Small' then 'max-w-s'
 			when 'Full' then 'max-w-full'
-			else 'max-w'
+			else 'max-w-l'
 		<%_ } _%>
 
 </script>

--- a/template/nuxt-app/components/blocks/simple-marquee.vue
+++ b/template/nuxt-app/components/blocks/simple-marquee.vue
@@ -2,7 +2,7 @@
 
 <template lang='pug'>
 
-section.simple-marquee.max-w-full: .max-w
+section.simple-marquee.max-w-full: .max-w-l
 
 	//- The title
 	h1.style-h1 {{ block.title }}

--- a/template/nuxt-app/components/layout/footer/footer.vue
+++ b/template/nuxt-app/components/layout/footer/footer.vue
@@ -2,7 +2,7 @@
 
 <template lang='pug'>
 
-footer.layout-footer: .max-w Footer content
+footer.layout-footer: .max-w-l Footer content
 
 </template>
 

--- a/template/nuxt-app/components/layout/header/desktop.vue
+++ b/template/nuxt-app/components/layout/header/desktop.vue
@@ -3,7 +3,7 @@
 <template lang='pug'>
 
 detachable-header.layout-header-desktop(:height='height')
-	header.max-w-full: .columns.max-w-medium
+	header.max-w-full: .columns.max-w-m
 		.left
 			//- Left aligned links
 

--- a/template/nuxt-app/components/layout/header/mobile.vue
+++ b/template/nuxt-app/components/layout/header/mobile.vue
@@ -3,7 +3,7 @@
 <template lang='pug'>
 
 detachable-header.layout-header-mobile(:height='height')
-	header.max-w-full: .columns.max-w-medium
+	header.max-w-full: .columns.max-w-m
 
 		.left
 			nuxt-link(to='/') <%= name %>

--- a/template/nuxt-app/components/pages/pdp/marquee.vue
+++ b/template/nuxt-app/components/pages/pdp/marquee.vue
@@ -2,7 +2,7 @@
 
 <template lang='pug'>
 
-.pdp-marquee: .max-w
+.pdp-marquee: .max-w-l
 
 	//- Example product data
 	h1 {{ product.title }}

--- a/template/nuxt-app/content/home.yml
+++ b/template/nuxt-app/content/home.yml
@@ -31,4 +31,4 @@ blocks:
   -
     __typename: 'mediaAsset'
     image: '/imgs/home/image.png'
-    maxWidth: 'max-w'
+    maxWidth: 'max-w-l'


### PR DESCRIPTION
@weotch I think making those naming conventions consistent is a great idea. I did that here. One caveat is that I kept `max-w-full` separate as `full`. It seems like that has a special use case, even though in reality it's really just an `max-w-xxl` with no gutters?

Let me know if you want me to do xxl, or just leave as full