### PR TITLE
Adding separate unique media query for header break

### DIFF
--- a/template/nuxt-app/assets/definitions.styl
+++ b/template/nuxt-app/assets/definitions.styl
@@ -118,3 +118,12 @@ fluid-space(property, size, negative = false)
 	fluid property,
 		mod * lookup('spacing-'+size),
 		mod * lookup('spacing-'+size+'-min')
+
+// separate header media queries
+// because header breaks at a unique width
+when-desktop-header()
+	@media(min-width header-break + 1px)
+		{block}
+when-mobile-header()
+	@media(max-width header-break)
+		{block}

--- a/template/nuxt-app/assets/vars/breakpoints.json
+++ b/template/nuxt-app/assets/vars/breakpoints.json
@@ -4,5 +4,5 @@
 	"tablet": "768px",
 	"mobile-landscape": "580px",
 	"mobile": "500px",
-	"nav-break": "1023px"
+	"header-break": "1023px"
 }

--- a/template/nuxt-app/components/blocks/simple-marquee.vue
+++ b/template/nuxt-app/components/blocks/simple-marquee.vue
@@ -37,9 +37,11 @@ export default
 	&:before
 		content ''
 		display block
-		+tablet-up()
+
+		// adjust height when header changes
+		+when-desktop-header()
 			height header-h
-		+tablet-down()
+		+when-mobile-header()
 			height mobile-header-h
 
 	// Add internal spacing

--- a/template/nuxt-app/components/layout/header/desktop.vue
+++ b/template/nuxt-app/components/layout/header/desktop.vue
@@ -38,8 +38,9 @@ export default
 <style src='./header.styl' lang='stylus' scoped></style>
 <style lang='stylus' scoped>
 
+// hide on mobile
 .layout-header-desktop
-	+tablet-down()
+	+when-mobile-header()
 		display none
 
 </style>

--- a/template/nuxt-app/components/layout/header/mobile.vue
+++ b/template/nuxt-app/components/layout/header/mobile.vue
@@ -36,8 +36,9 @@ export default
 <style src='./header.styl' lang='stylus' scoped></style>
 <style lang='stylus' scoped>
 
+// hide on desktop
 .layout-header-mobile
-	+tablet-up()
+	+when-desktop-header()
 		display none
 
 

--- a/template/nuxt-app/components/pages/pdp/marquee.vue
+++ b/template/nuxt-app/components/pages/pdp/marquee.vue
@@ -71,9 +71,11 @@ export default
 .pdp-marquee
 	padding-bottom spacing-m
 	background offwhite
-	+tablet-up()
+
+	// adjust spacing when header changes
+	+when-desktop-header()
 		padding-top header-h + spacing-m
-	+tablet-down()
+	+when-mobile-header()
 		padding-top header-h-mobile + spacing-m
 
 // Quick sections

--- a/template/nuxt-app/layouts/default.vue
+++ b/template/nuxt-app/layouts/default.vue
@@ -46,11 +46,13 @@ main
 .skip-content
 	position absolute
 	left -1000px
-	+tablet-up()
-		top (header-h + spacing-s)
-	+tablet-down()
-		top (header-h-mobile + spacing-s-min)
 	z-index header-z // stacked below nav but above page content
+
+	// adjust spacing when header changes
+	+when-desktop-header()
+		top (header-h + spacing-s)
+	+when-mobile-header()
+		top (header-h-mobile + spacing-s-min)
 
 	&:focus
 		fluid left, gutter, gutter-mobile

--- a/template/shopify-theme/components/layout/header-placeholder.vue
+++ b/template/shopify-theme/components/layout/header-placeholder.vue
@@ -31,9 +31,9 @@ export default
 	flex-center()
 
 	// Style header
-	+tablet-up()
+	+when-desktop-header()
 		height header-h
-	+tablet-down()
+	+when-mobile-header()
 		height header-h-mobile
 
 


### PR DESCRIPTION
I found that I need separate header breakpoints more often than not... And the header logic was linked to the tablet breakpoint. This is a similar naming convention to Clif, which I think makes sense, and is easily readable. 

I like keeping it separate from `tablet-landscape`, so we can adjust it specifically to fit the desktop nav in the designs... for example, I needed COR to be `1100` specifically

In breakpoints, it's `header-break`

The 2 media queries are `when-desktop-header` and `when-mobile-header`

based on this issue I made: https://github.com/BKWLD/create-cloak-app/issues/53 