### PR TITLE
Add a fixed-font helper

### DIFF
--- a/template/nuxt-app/assets/definitions.styl
+++ b/template/nuxt-app/assets/definitions.styl
@@ -7,7 +7,6 @@ json('vars/breakpoints.json')
 json('vars/dimensions.json')
 json('vars/colors.json')
 
-
 // Whitespace
 gutter = 60px
 gutter-mobile = 20px
@@ -70,7 +69,25 @@ body-font-size = 16px
  * Functions
  */
 
-// Set font styles shorthand
+// Shorthand for setting font styles with fixed font size
+fixed-font(style, size = null, color = null)
+
+	// Style switch statement
+	if style == 'body'
+		font-family ui-sans-serif, system-ui, sans-serif
+		letter-spacing -0.01em
+		font-weight 400
+	else if style == 'code'
+		font-family ui-monospace, monospace
+		font-weight 400
+
+	// Set size and color if provided
+	if size
+		font-size size
+	if color
+		color color
+
+// Shorthand for setting font styles with fluid font-size
 fluid-font(style,
 	max-size = null,
 	min-size = null,
@@ -78,18 +95,11 @@ fluid-font(style,
 	max-break = null,
 	min-break = 375)
 
-	// Font style switch statement.
-	if style == 'body'
-		font-family sans-serif
-		letter-spacing -0.01em
-		font-weight 400
+	// Set font-family and other configs
+	fixed-font style, null, color
 
 	// Set font-size
 	fluid font-size, max-size, min-size, max-break, min-break
-
-	// Set color, if provided
-	if color
-		color color
 
 // Style guide styles. The line-height fractions are based on the brand
 // style guidelines


### PR DESCRIPTION
On Owlet, I noticed a number of [cases like](https://gitlab.com/owlet-baby-care/owletcare.com/-/blob/ec0815be62e51460e1003f8a1879091d26495d14/library/components/layout/cart-flyout/cart-flyout.vue#L224):

```stylus
fluid-font 'bold', 14, 14
```

Aka, repeating the font-size because we didn't want it to resize but we did want to use the `bold` styling.  

This PR would add `fixed-font()` so you could do:

```stylus
fixed-font 'bold', 14
```

It's also used by `fluid-font` so we only maintain the switch statement with style shorthands in one place.

@BKWLD/devs thoughts?  Thoughts on the method name too?  I like never use the `font` shorthand so we could overwrite that.  Or maybe `font-style`?