### PR TITLE
Updating the readme with new global yarn install, etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,6 @@ Sets up a new [Cloak](https://github.com/BKWLD/cloak) (Nuxt + CMS) based project
 
 ![](https://i.pinimg.com/originals/75/af/04/75af04c5f9fa6e26231640f7d368f042.gif)
 
-## Install
-
-If installing fresh, or upgrading from version 2
-`yarn global add create-cloak-app@^3`
-
 ## Usage
 
 From the directory you want to create the new Cloak app:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ Sets up a new [Cloak](https://github.com/BKWLD/cloak) (Nuxt + CMS) based project
 
 ![](https://i.pinimg.com/originals/75/af/04/75af04c5f9fa6e26231640f7d368f042.gif)
 
+## Install
+
+If installing fresh, or upgrading from version 2
+`yarn global add create-cloak-app@^3`
+
 ## Usage
 
 From the directory you want to create the new Cloak app:
@@ -13,7 +18,7 @@ From the directory you want to create the new Cloak app:
 yarn create cloak-app
 
 # Use previous major version if Contentful or Shopify
-yarn install -g create-cloak-app@^2
+yarn global add create-cloak-app@^2
 create-cloak-app
 ```
 


### PR DESCRIPTION
When updating, I got a notice that said --global is being deprecated, and the better way to add/update global packages is `yarn global add xxx`

Also added a note about installing fresh or updating from v2